### PR TITLE
Fix undo/unload issue

### DIFF
--- a/QuickServe/js/app.js
+++ b/QuickServe/js/app.js
@@ -41,7 +41,10 @@ class QuickServeApp {
 
     async loadServices() {
         try {
-            const response = await fetch('./services.json');
+            const response = await fetch('/services.json');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
             this.services = await response.json();
         } catch (error) {
             console.error('Failed to load services:', error);


### PR DESCRIPTION
Fix loading screen not hiding by correcting the fetch path for `services.json` and adding error handling.

The `services.json` file was moved to the `public/` directory, but the application was still trying to fetch it from `./services.json`. With Vite, files in `public/` are served from the root path (`/`). This caused a 404 error, preventing the app from initializing and consequently leaving the loading screen visible indefinitely. The fix updates the fetch path to `/services.json` and adds a check for HTTP errors to ensure proper loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-918525fd-2b22-453e-bc06-3b2951c1e09e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-918525fd-2b22-453e-bc06-3b2951c1e09e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

